### PR TITLE
webpack 2 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,13 +17,16 @@
     "babel-core": "^6.4.0",
     "babel-loader": "^6.2.1",
     "babel-plugin-transform-object-rest-spread": "^6.3.13",
-    "babel-preset-es2015": "^6.3.13",
-    "bundle-loader": "^0.5.4",
-    "webpack": "^1.12.10",
-    "webpack-dev-server": "^1.14.1"
+    "babel-preset-es2015-native-modules": "^6.9.0",
+    "webpack": "2.1.0-beta.17",
+    "webpack-dev-server": "2.1.0-beta.0"
   },
   "babel": {
-    "presets": ["es2015"],
-    "plugins": ["transform-object-rest-spread"]
+    "presets": [
+      "babel-preset-es2015-native-modules"
+    ],
+    "plugins": [
+      "transform-object-rest-spread"
+    ]
   }
 }

--- a/src/router.js
+++ b/src/router.js
@@ -22,12 +22,12 @@ export default Backbone.Router.extend({
     const mini_app = AppFinder(path);
 
     if (mini_app) {
-      const handler = require('bundle!./apps/' + mini_app.name + '/index.js');
-      handler(bundle => {
+      const handler = System.import(`./apps/${mini_app.name}/index.js`);
+      handler.then(bundle => {
         const App = bundle.default;
         App();
         Backbone.history.loadUrl(); // just refreshing the current path, because we've added new paths that we can handle
-      });
+      }).catch(() => alert("can't load the bundle"));
     } else {
       alert('404');
     }


### PR DESCRIPTION
We can merge this when webpack 2 is officially released.
### Outputs to compare

<details>
<summary>

Webpack 1 otput</summary>



```
Hash: e270036314c684f59389
Version: webpack 1.13.1
Time: 736ms
      Asset     Size  Chunks             Chunk Names
  bundle.js   405 kB       0  [emitted]  main
1.bundle.js  1.19 kB       1  [emitted]
2.bundle.js  1.23 kB       2  [emitted]
   [6] ./src/apps metadata\.js$ 208 bytes {0} [built]
    + 17 hidden modules
```

</details>

<details>
<summary>

Webpack 2 otput</summary>



```
Hash: 283a35edd1a7eeac28b0
Version: webpack 2.1.0-beta.17
Time: 888ms
      Asset     Size  Chunks             Chunk Names
0.bundle.js  1.23 kB       0  [emitted]
1.bundle.js   1.2 kB       1  [emitted]
  bundle.js   397 kB       2  [emitted]  main
  [10] ./src/apps metadata\.js$ 208 bytes {2} [built]
  [11] ./src/apps async ^\.\/.*\/index\.js$ 160 bytes {2} [built]
    + 15 hidden modules
```

</details>
